### PR TITLE
mali_exa.c: add missing include

### DIFF
--- a/src/mali_exa.c
+++ b/src/mali_exa.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <xorg-server.h>
 #include <xf86.h>
 
 #include "mali_def.h"


### PR DESCRIPTION
Needed for newer xorg: xorg-server.h must be included before xf86.h.  Doesn't hurt old ones.
